### PR TITLE
[Schema] footprint type, pos 변경 & user's vegan type 변경 & recipe's weight, photo 삭제

### DIFF
--- a/prisma/migrations/20230306083432_change_about_carbon_footprint_and_user_s_vegan_type/migration.sql
+++ b/prisma/migrations/20230306083432_change_about_carbon_footprint_and_user_s_vegan_type/migration.sql
@@ -1,0 +1,28 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `carbon_footprint` on the `ingredient_category` table. All the data in the column will be lost.
+  - You are about to drop the column `photo` on the `recipe` table. All the data in the column will be lost.
+  - You are about to alter the column `carbon_footprint` on the `recipe` table. The data in that column could be lost. The data in that column will be cast from `Decimal(65,30)` to `DoublePrecision`.
+  - You are about to drop the column `weight` on the `recipe_ingredient` table. All the data in the column will be lost.
+  - You are about to drop the column `type_id` on the `user` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "user" DROP CONSTRAINT "user_type_id_fkey";
+
+-- AlterTable
+ALTER TABLE "ingredient" ADD COLUMN     "carbon_footprint" DOUBLE PRECISION NOT NULL DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "ingredient_category" DROP COLUMN "carbon_footprint";
+
+-- AlterTable
+ALTER TABLE "recipe" DROP COLUMN "photo",
+ALTER COLUMN "carbon_footprint" SET DATA TYPE DOUBLE PRECISION;
+
+-- AlterTable
+ALTER TABLE "recipe_ingredient" DROP COLUMN "weight";
+
+-- AlterTable
+ALTER TABLE "user" DROP COLUMN "type_id";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,14 +12,11 @@ datasource db {
 
 model User {
   id        String    @id
-  typeId    String    @map("type_id")
   createdAt DateTime  @default(now()) @map("created_at")
   updatedAt DateTime  @updatedAt @map("updated_at")
   deletedAt DateTime? @map("deleted_at")
   name      String    @unique
   photo     String?
-
-  VeganType VeganType @relation(fields: [typeId], references: [id])
 
   Recipe         Recipe[]
   Meal           Meal[]
@@ -36,9 +33,8 @@ model Recipe {
   updatedAt       DateTime  @updatedAt @map("updated_at")
   deletedAt       DateTime? @map("deleted_at")
   name            String
-  photo           String?
   duration        Int       @default(0)
-  carbonFootprint Decimal   @default(0) @map("carbon_footprint")
+  carbonFootprint Float     @default(0) @map("carbon_footprint")
 
   User      User      @relation(fields: [userId], references: [id])
   VeganType VeganType @relation(fields: [typeId], references: [id])
@@ -97,9 +93,10 @@ model RecipeBookmark {
 }
 
 model Ingredient {
-  id         String @id @default(uuid())
-  categoryId String @map("category_id")
-  name       String
+  id              String @id @default(uuid())
+  categoryId      String @map("category_id")
+  name            String
+  carbonFootprint Float  @default(0) @map("carbon_footprint")
 
   IngredientCategory IngredientCategory @relation(fields: [categoryId], references: [id])
 
@@ -109,9 +106,8 @@ model Ingredient {
 }
 
 model IngredientCategory {
-  id              String  @id @default(uuid())
-  name            String
-  carbonFootprint Decimal @default(0) @map("carbon_footprint")
+  id   String @id @default(uuid())
+  name String
 
   Ingredient                  Ingredient[]
   VeganTypeIngredientCategory VeganTypeIngredientCategory[]
@@ -125,7 +121,6 @@ model RecipeIngredient {
   ingredientId String   @map("ingredient_id")
   createdAt    DateTime @default(now()) @map("created_at")
   updatedAt    DateTime @updatedAt @map("updated_at")
-  weight       Int      @default(0)
 
   Recipe     Recipe     @relation(fields: [recipeId], references: [id])
   Ingredient Ingredient @relation(fields: [ingredientId], references: [id])
@@ -138,7 +133,6 @@ model VeganType {
   name String
 
   Recipe                      Recipe[]
-  User                        User[]
   VeganTypeIngredientCategory VeganTypeIngredientCategory[]
 
   @@map("vegan_type")


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [ ] Improvement
- [X] New feature
- [ ] Bug fix
- [ ] CI/CD, INFRA
- [ ] Etc

## Purpose
- carbon footprint의 위치를 category에서 ingedient로 이동하고, 타입을 부동 소수점 타입 `Float`으로 변경합니다.
- user colum에서 vegan type을 삭제합니다.
- recipe에서 photo를 삭제합니다.
- recipe에 재료 등록시에 무게를 등록하지 않도록 weight를 삭제합니다.

## Related issue
- resolve #16 

## Additional context
- local에서는 db에 반영하고, prisma generate해줘야 사용 가능합니다. 계속 타입에러뜨면 IDE 껏다가 켜주세요.