### PR TITLE
[Feat] 회원가입 로직 & Guard 에서 vegan type 삭제

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,5 @@
 ## Type
-
 PR 종류를 확인해 주세요.
-
 - [ ] Improvement
 - [ ] New feature
 - [ ] Bug fix

--- a/src/auth/auth.repository.ts
+++ b/src/auth/auth.repository.ts
@@ -12,13 +12,11 @@ export class AuthRepository {
       data: {
         id: data.id,
         name: data.name,
-        typeId: data.typeId,
       },
       select: {
         id: true,
         name: true,
         photo: true,
-        VeganType: true,
       },
     });
   }
@@ -44,15 +42,5 @@ export class AuthRepository {
       },
     });
     return !!user;
-  }
-
-  async isVeganTypeValid(typeId: string): Promise<boolean> {
-    const veganType = await this.prisma.veganType.findUnique({
-      where: {
-        id: typeId,
-      },
-    });
-
-    return !!veganType;
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -15,10 +15,9 @@ export class AuthService {
     payload: RegisterPayload,
     userId: string,
   ): Promise<UserInfoWithType> {
-    const [isDuplicateName, isUserExist, isVeganTypeValid] = await Promise.all([
+    const [isDuplicateName, isUserExist] = await Promise.all([
       this.authRepository.checkDuplicateName(payload.name),
       this.authRepository.isUserExist(userId),
-      this.authRepository.isVeganTypeValid(payload.typeId),
     ]);
 
     if (isDuplicateName) {
@@ -29,14 +28,9 @@ export class AuthService {
       throw new ConflictException('이미 존재하는 사용자입니다.');
     }
 
-    if (!isVeganTypeValid) {
-      throw new NotFoundException('존재하지 않는 비건유형입니다.');
-    }
-
     return this.authRepository.register({
       id: userId,
       name: payload.name,
-      typeId: payload.typeId,
     });
   }
 

--- a/src/auth/dto/user-info.dto.ts
+++ b/src/auth/dto/user-info.dto.ts
@@ -1,20 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { UserInfoWithType } from '../type/user-info-with-type.type';
 
-class VeganTypeDto {
-  @ApiProperty({
-    type: String,
-    description: '비건 타입 Id',
-  })
-  id!: string;
-
-  @ApiProperty({
-    type: String,
-    description: '비건 타입 이름',
-  })
-  name!: string;
-}
-
 export class UserInfoDto {
   @ApiProperty({
     type: String,
@@ -29,12 +15,6 @@ export class UserInfoDto {
   name!: string;
 
   @ApiProperty({
-    type: VeganTypeDto,
-    description: '비건 타입',
-  })
-  veganType!: VeganTypeDto;
-
-  @ApiProperty({
     type: String,
     description: '유저 사진',
   })
@@ -45,10 +25,6 @@ export class UserInfoDto {
       id: data.id,
       name: data.name,
       photo: data.photo,
-      veganType: {
-        id: data.VeganType.id,
-        name: data.VeganType.name,
-      },
     };
   }
 }

--- a/src/auth/guard/auth.guard.ts
+++ b/src/auth/guard/auth.guard.ts
@@ -37,7 +37,6 @@ export class FirebaseAuthGuard implements CanActivate {
       },
       select: {
         id: true,
-        typeId: true,
         name: true,
         photo: true,
       },

--- a/src/auth/payload/register.payload.ts
+++ b/src/auth/payload/register.payload.ts
@@ -9,12 +9,4 @@ export class RegisterPayload {
     description: '닉네임',
   })
   name!: string;
-
-  @IsDefined()
-  @IsString()
-  @ApiProperty({
-    type: String,
-    description: '비건 타입 Id',
-  })
-  typeId!: string;
 }

--- a/src/auth/type/register-data.type.ts
+++ b/src/auth/type/register-data.type.ts
@@ -1,5 +1,4 @@
 export type RegisterData = {
   id: string;
   name: string;
-  typeId: string;
 };

--- a/src/auth/type/user-info-with-type.type.ts
+++ b/src/auth/type/user-info-with-type.type.ts
@@ -1,9 +1,6 @@
 export type UserInfoWithType = {
   id: string;
   name: string;
-  VeganType: {
-    id: string;
-    name: string;
-  };
+
   photo: string | null;
 };

--- a/src/auth/type/user-info.type.ts
+++ b/src/auth/type/user-info.type.ts
@@ -1,6 +1,5 @@
 export type UserInfo = {
   id: string;
   name: string;
-  typeId: string;
   photo: string | null;
 };


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [ ] Improvement
- [X] New feature
- [ ] Bug fix
- [ ] CI/CD, INFRA
- [ ] Etc

## Purpose
- 기존에 있던 회원가입 로직에서 vegan type 관련 부분을 제거합니다.
- 마찬가지로, guard에서 가져오는 userInfo type에서도 typeId를 제거합니다.

## Why
- users에서 vegan type을 제외하도록 스키마를 변경(#17 )에 따른 결과입니다.

## Related issue
- resolve #18 

## Additional context
- 추가로 알리고 싶으신 내용이 있으신가요?

## Checklist
- #17 이후에 머지합니다.
