### PR TITLE
[Feat] Ingredient Module 추가

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,9 +5,16 @@ import { configModule } from './modules/config.module';
 import { CommonModule } from '../common/common.module';
 import { AuthModule } from '../auth/auth.module';
 import { FirebaseModule } from '../auth/firebase/firebase.module';
+import { IngredientModule } from '../ingredient/ingredient.module';
 
 @Module({
-  imports: [configModule, CommonModule, FirebaseModule, AuthModule],
+  imports: [
+    configModule,
+    CommonModule,
+    FirebaseModule,
+    AuthModule,
+    IngredientModule,
+  ],
   controllers: [AppController],
 })
 export class AppModule implements NestModule {

--- a/src/common/dto/bulk-create.dto.ts
+++ b/src/common/dto/bulk-create.dto.ts
@@ -6,4 +6,10 @@ export class BulkCreateDto {
     description: '성공한 데이터 개수',
   })
   count!: number;
+
+  static of(count: number): BulkCreateDto {
+    return {
+      count,
+    };
+  }
 }

--- a/src/common/dto/bulk-create.dto.ts
+++ b/src/common/dto/bulk-create.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class BulkCreateDto {
+  @ApiProperty({
+    type: Number,
+    description: '성공한 데이터 개수',
+  })
+  count!: number;
+}

--- a/src/ingredient/dto/category-with-ingredient-list.dto.ts
+++ b/src/ingredient/dto/category-with-ingredient-list.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { CategoryWithIngredientList } from '../type/category-with-ingredient-list.type';
 
 export class IngredientDto {
   @ApiProperty({
@@ -38,4 +39,17 @@ export class CategoryWithIngredientListDto {
     description: '카테고리에 속한 재료 리스트',
   })
   ingredientList!: IngredientDto[];
+  static of(
+    category: CategoryWithIngredientList,
+  ): CategoryWithIngredientListDto {
+    return {
+      id: category.id,
+      name: category.name,
+      ingredientList: category.Ingredient.map((ingredient) => ({
+        id: ingredient.id,
+        name: ingredient.name,
+        carbonFootprint: ingredient.carbonFootprint,
+      })),
+    };
+  }
 }

--- a/src/ingredient/dto/category-with-ingredient-list.dto.ts
+++ b/src/ingredient/dto/category-with-ingredient-list.dto.ts
@@ -1,0 +1,41 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class IngredientDto {
+  @ApiProperty({
+    type: String,
+    description: '재료 ID',
+  })
+  id!: string;
+
+  @ApiProperty({
+    type: String,
+    description: '재료 이름',
+  })
+  name!: string;
+
+  @ApiProperty({
+    type: Number,
+    description: '탄소발자국',
+  })
+  carbonFootprint!: number;
+}
+
+export class CategoryWithIngredientListDto {
+  @ApiProperty({
+    type: String,
+    description: '카테고리 ID',
+  })
+  id!: string;
+
+  @ApiProperty({
+    type: String,
+    description: '카테고리 이름',
+  })
+  name!: string;
+
+  @ApiProperty({
+    type: [IngredientDto],
+    description: '카테고리에 속한 재료 리스트',
+  })
+  ingredientList!: IngredientDto[];
+}

--- a/src/ingredient/dto/ingredient-with-category.dto.ts
+++ b/src/ingredient/dto/ingredient-with-category.dto.ts
@@ -1,0 +1,41 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class IngredientCategoryDto {
+  @ApiProperty({
+    type: String,
+    description: '재료 카테고리 ID',
+  })
+  id!: string;
+
+  @ApiProperty({
+    type: String,
+    description: '재료 카테고리 이름',
+  })
+  name!: string;
+}
+
+export class IngredientWithCategoryDto {
+  @ApiProperty({
+    type: String,
+    description: '재료 ID',
+  })
+  id!: string;
+
+  @ApiProperty({
+    type: String,
+    description: '재료 이름',
+  })
+  name!: string;
+
+  @ApiProperty({
+    type: Number,
+    description: '탄소발자국',
+  })
+  carbonFootprint!: number;
+
+  @ApiProperty({
+    type: IngredientCategoryDto,
+    description: '카테고리 정보',
+  })
+  category!: IngredientCategoryDto;
+}

--- a/src/ingredient/dto/ingredient-with-category.dto.ts
+++ b/src/ingredient/dto/ingredient-with-category.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { IngredientWithCategory } from '../type/ingredient-with-category.type';
 
 export class IngredientCategoryDto {
   @ApiProperty({
@@ -38,4 +39,16 @@ export class IngredientWithCategoryDto {
     description: '카테고리 정보',
   })
   category!: IngredientCategoryDto;
+
+  static of(ingredient: IngredientWithCategory): IngredientWithCategoryDto {
+    return {
+      id: ingredient.id,
+      name: ingredient.name,
+      carbonFootprint: ingredient.carbonFootprint,
+      category: {
+        id: ingredient.IngredientCategory.id,
+        name: ingredient.IngredientCategory.name,
+      },
+    };
+  }
 }

--- a/src/ingredient/ingredient.controller.ts
+++ b/src/ingredient/ingredient.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, Param } from '@nestjs/common';
 import { IngredientService } from './ingredient.service';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { IngredientWithCategoryDto } from './dto/ingredient-with-category.dto';
-import { string } from 'joi';
+import { CategoryWithIngredientListDto } from './dto/category-with-ingredient-list.dto';
 
 @Controller('ingredients')
 @ApiTags('Ingredient API')
@@ -17,6 +17,17 @@ export class IngredientController {
   ): Promise<IngredientWithCategoryDto> {
     return IngredientWithCategoryDto.of(
       await this.ingredientService.getIngredientById(ingredientId),
+    );
+  }
+
+  @Get('categories/:categoryId')
+  @ApiOperation({ summary: '특정 카테고리의 재료 정보 가져오기' })
+  @ApiOkResponse({ type: [CategoryWithIngredientListDto] })
+  async getCategoryWithIngredientList(
+    @Param('categoryId') categoryId: string,
+  ): Promise<CategoryWithIngredientListDto> {
+    return CategoryWithIngredientListDto.of(
+      await this.ingredientService.getCategoryWithIngredientList(categoryId),
     );
   }
 }

--- a/src/ingredient/ingredient.controller.ts
+++ b/src/ingredient/ingredient.controller.ts
@@ -1,9 +1,22 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Get, Param } from '@nestjs/common';
 import { IngredientService } from './ingredient.service';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { IngredientWithCategoryDto } from './dto/ingredient-with-category.dto';
+import { string } from 'joi';
 
-@Controller('ingredient')
+@Controller('ingredients')
 @ApiTags('Ingredient API')
 export class IngredientController {
   constructor(private readonly ingredientService: IngredientService) {}
+
+  @Get(':ingredientId')
+  @ApiOperation({ summary: 'id로 재료 정보 가져오기' })
+  @ApiOkResponse({ type: IngredientWithCategoryDto })
+  async getIngredientById(
+    @Param('ingredientId') ingredientId: string,
+  ): Promise<IngredientWithCategoryDto> {
+    return IngredientWithCategoryDto.of(
+      await this.ingredientService.getIngredientById(ingredientId),
+    );
+  }
 }

--- a/src/ingredient/ingredient.controller.ts
+++ b/src/ingredient/ingredient.controller.ts
@@ -1,6 +1,11 @@
 import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 import { IngredientService } from './ingredient.service';
-import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
 import { IngredientWithCategoryDto } from './dto/ingredient-with-category.dto';
 import { CategoryWithIngredientListDto } from './dto/category-with-ingredient-list.dto';
 import { BulkCreateDto } from '../common/dto/bulk-create.dto';
@@ -13,7 +18,7 @@ export class IngredientController {
 
   @Post('bulk')
   @ApiOperation({ summary: '재료 정보 일괄 등록' })
-  @ApiOkResponse({ type: BulkCreateDto })
+  @ApiCreatedResponse({ type: BulkCreateDto })
   async bulkCreateIngredient(
     @Body() payload: IngredientBulkCreatePayload,
   ): Promise<BulkCreateDto> {

--- a/src/ingredient/ingredient.controller.ts
+++ b/src/ingredient/ingredient.controller.ts
@@ -1,13 +1,26 @@
-import { Controller, Get, Param } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
 import { IngredientService } from './ingredient.service';
 import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { IngredientWithCategoryDto } from './dto/ingredient-with-category.dto';
 import { CategoryWithIngredientListDto } from './dto/category-with-ingredient-list.dto';
+import { BulkCreateDto } from '../common/dto/bulk-create.dto';
+import { IngredientBulkCreatePayload } from './payload/ingredient-bulk-create.payload';
 
 @Controller('ingredients')
 @ApiTags('Ingredient API')
 export class IngredientController {
   constructor(private readonly ingredientService: IngredientService) {}
+
+  @Post('bulk')
+  @ApiOperation({ summary: '재료 정보 일괄 등록' })
+  @ApiOkResponse({ type: BulkCreateDto })
+  async bulkCreateIngredient(
+    @Body() payload: IngredientBulkCreatePayload,
+  ): Promise<BulkCreateDto> {
+    return BulkCreateDto.of(
+      await this.ingredientService.bulkCreateIngredient(payload),
+    );
+  }
 
   @Get(':ingredientId')
   @ApiOperation({ summary: 'id로 재료 정보 가져오기' })

--- a/src/ingredient/ingredient.controller.ts
+++ b/src/ingredient/ingredient.controller.ts
@@ -1,0 +1,9 @@
+import { Controller } from '@nestjs/common';
+import { IngredientService } from './ingredient.service';
+import { ApiTags } from '@nestjs/swagger';
+
+@Controller('ingredient')
+@ApiTags('Ingredient API')
+export class IngredientController {
+  constructor(private readonly ingredientService: IngredientService) {}
+}

--- a/src/ingredient/ingredient.module.ts
+++ b/src/ingredient/ingredient.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { IngredientController } from './ingredient.controller';
+import { IngredientService } from './ingredient.service';
+import { IngredientRepository } from './ingredient.repository';
+
+@Module({
+  controllers: [IngredientController],
+  providers: [IngredientService, IngredientRepository],
+})
+export class IngredientModule {}

--- a/src/ingredient/ingredient.repository.ts
+++ b/src/ingredient/ingredient.repository.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../common/services/prisma.service';
 import { IngredientWithCategory } from './type/ingredient-with-category.type';
+import { CategoryWithIngredientList } from './type/category-with-ingredient-list.type';
 
 @Injectable()
 export class IngredientRepository {
@@ -21,6 +22,27 @@ export class IngredientRepository {
           select: {
             id: true,
             name: true,
+          },
+        },
+      },
+    });
+  }
+
+  async getCategoryWithIngredientList(
+    categoryId: string,
+  ): Promise<CategoryWithIngredientList | null> {
+    return this.prisma.ingredientCategory.findUnique({
+      where: {
+        id: categoryId,
+      },
+      select: {
+        id: true,
+        name: true,
+        Ingredient: {
+          select: {
+            id: true,
+            name: true,
+            carbonFootprint: true,
           },
         },
       },

--- a/src/ingredient/ingredient.repository.ts
+++ b/src/ingredient/ingredient.repository.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../common/services/prisma.service';
+
+@Injectable()
+export class IngredientRepository {
+  constructor(private readonly prisma: PrismaService) {}
+}

--- a/src/ingredient/ingredient.repository.ts
+++ b/src/ingredient/ingredient.repository.ts
@@ -2,10 +2,19 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../common/services/prisma.service';
 import { IngredientWithCategory } from './type/ingredient-with-category.type';
 import { CategoryWithIngredientList } from './type/category-with-ingredient-list.type';
+import { IngredientCreateInput } from './type/ingredient-create-input.type';
 
 @Injectable()
 export class IngredientRepository {
   constructor(private readonly prisma: PrismaService) {}
+
+  async bulkCreateIngredient(data: IngredientCreateInput[]): Promise<number> {
+    const result = await this.prisma.ingredient.createMany({
+      data,
+    });
+
+    return result.count;
+  }
 
   async getIngredientById(
     ingredientId: string,
@@ -47,5 +56,20 @@ export class IngredientRepository {
         },
       },
     });
+  }
+
+  async isCategoryListExist(categoryIds: string[]): Promise<boolean> {
+    const categoryList = await this.prisma.ingredientCategory.findMany({
+      where: {
+        id: {
+          in: categoryIds,
+        },
+      },
+      select: {
+        id: true,
+      },
+    });
+
+    return categoryList.length === categoryIds.length;
   }
 }

--- a/src/ingredient/ingredient.repository.ts
+++ b/src/ingredient/ingredient.repository.ts
@@ -1,7 +1,29 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../common/services/prisma.service';
+import { IngredientWithCategory } from './type/ingredient-with-category.type';
 
 @Injectable()
 export class IngredientRepository {
   constructor(private readonly prisma: PrismaService) {}
+
+  async getIngredientById(
+    ingredientId: string,
+  ): Promise<IngredientWithCategory | null> {
+    return this.prisma.ingredient.findUnique({
+      where: {
+        id: ingredientId,
+      },
+      select: {
+        id: true,
+        name: true,
+        carbonFootprint: true,
+        IngredientCategory: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
+    });
+  }
 }

--- a/src/ingredient/ingredient.service.ts
+++ b/src/ingredient/ingredient.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@nestjs/common';
+import { IngredientRepository } from './ingredient.repository';
+
+@Injectable()
+export class IngredientService {
+  constructor(private readonly ingredientRepository: IngredientRepository) {}
+}

--- a/src/ingredient/ingredient.service.ts
+++ b/src/ingredient/ingredient.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { IngredientRepository } from './ingredient.repository';
 import { IngredientWithCategory } from './type/ingredient-with-category.type';
+import { CategoryWithIngredientList } from './type/category-with-ingredient-list.type';
 
 @Injectable()
 export class IngredientService {
@@ -18,5 +19,18 @@ export class IngredientService {
     }
 
     return ingredient;
+  }
+
+  async getCategoryWithIngredientList(
+    categoryId: string,
+  ): Promise<CategoryWithIngredientList> {
+    const category =
+      await this.ingredientRepository.getCategoryWithIngredientList(categoryId);
+
+    if (!category) {
+      throw new NotFoundException('존재하지 않는 Category입니다.');
+    }
+
+    return category;
   }
 }

--- a/src/ingredient/ingredient.service.ts
+++ b/src/ingredient/ingredient.service.ts
@@ -1,7 +1,22 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { IngredientRepository } from './ingredient.repository';
+import { IngredientWithCategory } from './type/ingredient-with-category.type';
 
 @Injectable()
 export class IngredientService {
   constructor(private readonly ingredientRepository: IngredientRepository) {}
+
+  async getIngredientById(
+    ingredientId: string,
+  ): Promise<IngredientWithCategory> {
+    const ingredient = await this.ingredientRepository.getIngredientById(
+      ingredientId,
+    );
+
+    if (!ingredient) {
+      throw new NotFoundException('존재하지 않는 Ingredient입니다.');
+    }
+
+    return ingredient;
+  }
 }

--- a/src/ingredient/payload/ingredient-bulk-create.payload.ts
+++ b/src/ingredient/payload/ingredient-bulk-create.payload.ts
@@ -1,0 +1,47 @@
+import {
+  IsArray,
+  IsDefined,
+  IsNumber,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+class IngredientCreatePayload {
+  @IsDefined()
+  @IsString()
+  @ApiProperty({
+    description: '재료 이름',
+    type: String,
+  })
+  name!: string;
+
+  @IsDefined()
+  @IsNumber()
+  @ApiProperty({
+    description: '탄소발자국',
+    type: Number,
+  })
+  carbonFootprint!: number;
+
+  @IsDefined()
+  @IsString()
+  @ApiProperty({
+    description: '카테고리 ID',
+    type: String,
+  })
+  categoryId!: string;
+}
+
+export class IngredientBulkCreatePayload {
+  @IsDefined()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => IngredientCreatePayload)
+  @ApiProperty({
+    description: '등록하려는 재료 목록',
+    type: [IngredientCreatePayload],
+  })
+  ingredientList!: IngredientCreatePayload[];
+}

--- a/src/ingredient/type/category-with-ingredient-list.type.ts
+++ b/src/ingredient/type/category-with-ingredient-list.type.ts
@@ -1,0 +1,9 @@
+export type CategoryWithIngredientList = {
+  id: string;
+  name: string;
+  Ingredient: {
+    id: string;
+    name: string;
+    carbonFootprint: number;
+  }[];
+};

--- a/src/ingredient/type/ingredient-create-input.type.ts
+++ b/src/ingredient/type/ingredient-create-input.type.ts
@@ -1,0 +1,6 @@
+export type IngredientCreateInput = {
+  name: string;
+  carbonFootprint: number;
+
+  categoryId: string;
+};

--- a/src/ingredient/type/ingredient-with-category.type.ts
+++ b/src/ingredient/type/ingredient-with-category.type.ts
@@ -1,0 +1,9 @@
+export type IngredientWithCategory = {
+  id: string;
+  name: string;
+  carbonFootprint: number;
+  IngredientCategory: {
+    id: string;
+    name: string;
+  };
+};


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [ ] Improvement
- [X] New feature
- [ ] Bug fix
- [ ] CI/CD, INFRA
- [ ] Etc

## Purpose
- ingredient를 추가하고 조회할 수 있는 메소드 3개를 구현했습니다. 자세한 명세는 docs 참고해주세요.
1. POST ingredients/bulk => 재료를 여러개 bulk로 등록할 수 있습니다.
2. GET ingredients/categories/categoryId => 특정 카테고리의 재료 리스트를 불러옵니다.
3. GET ingredients/:ingredientId => id로 재료를 조회합니다.


## Related issue
- resolve #13 

## Additional context
- client에서 사용할 api는 아니어서 그냥 guard 안붙였습니다.
