### PR TITLE
[Feat] Login API

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -2,24 +2,29 @@ import {
   Body,
   Controller,
   Get,
-  Inject,
   Param,
   Post,
   Req,
   UnauthorizedException,
+  UseGuards,
 } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import {
   ApiBearerAuth,
+  ApiCreatedResponse,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
+  ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 import { CheckDuplicateDto } from './dto/check-duplicate.dto';
 import { RequestWithAuth } from './type/request-with.auth.type';
 import { FirebaseService } from './firebase/firebase.service';
 import { UserInfoDto } from './dto/user-info.dto';
 import { RegisterPayload } from './payload/register.payload';
+import { FirebaseAuthGuard } from './guard/auth.guard';
+import { CurrentUser } from './decorator/user.decorator';
+import { UserData } from './type/user-data.type';
 
 @Controller('auth')
 @ApiTags('Auth API')
@@ -51,6 +56,16 @@ export class AuthController {
     return UserInfoDto.of(
       await this.authService.register(createUserPayload, userId),
     );
+  }
+
+  @Post('login')
+  @UseGuards(FirebaseAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '로그인합니다.' })
+  @ApiCreatedResponse({ type: UserInfoDto })
+  @ApiUnauthorizedResponse({ description: '인증되지 않은 사용자입니다.' })
+  async login(@CurrentUser() user: UserData): Promise<UserInfoDto> {
+    return UserInfoDto.of(user);
   }
 
   @Get('name/:name/duplicate')


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [ ] Improvement
- [X] New feature
- [ ] Bug fix
- [ ] CI/CD, INFRA
- [ ] Etc

## Purpose
- 헤더 토큰의 정보가 유효하면 user정보를 내리고, 없으면 401이 나가는 api입니다.
- 사실상 FirebaseAuthGuard가 하는 일이랑 동일해서, Guard를 나온 데이터를 바로 컨트롤러 단에서 DTO로 포맷팅해서 내보냅니다.

## Related issue
- resolve #49 

## Additional context
- url을 어떻게 할지는 좀더 고민해봐야 할 것 같아요.

## Checklist
- 간단한 구현이라 바로 머지하겠습니다!
