### PR TITLE
[Fix] 썸네일 사진 선택 로직 수정

### DIFF
--- a/src/meal/meal.service.ts
+++ b/src/meal/meal.service.ts
@@ -28,7 +28,7 @@ export class MealService {
     return this.mealRepository.createMeal(input);
   }
   async getMealById(userId: string, mealId: string): Promise<MealDto> {
-    const meal = await this.mealRepository.getMealById(mealId, userId);
+    const meal = await this.mealRepository.getMealById(mealId);
 
     if (!meal) {
       throw new NotFoundException('존재하지 않는 식단ID입니다.');

--- a/src/recipe/recipe.controller.ts
+++ b/src/recipe/recipe.controller.ts
@@ -44,17 +44,6 @@ export class RecipeController {
   ): Promise<RecipeBookmarkDto> {
     return this.recipeService.toggleRecipeBookmark(user.id, recipeId);
   }
-  @Get(':recipeId')
-  @UseGuards(FirebaseAuthGuard)
-  @ApiBearerAuth()
-  @ApiOperation({ summary: '레시피 ID로 조회' })
-  @ApiOkResponse({ type: RecipeDto })
-  async getRecipeById(
-    @CurrentUser() user: UserData,
-    @Param('recipeId') recipeId: string,
-  ): Promise<RecipeDto> {
-    return this.recipeService.getRecipeById(recipeId, user.id);
-  }
 
   @Get('users/:userId')
   @UseGuards(FirebaseAuthGuard)
@@ -76,5 +65,17 @@ export class RecipeController {
     @CurrentUser() user: UserData,
   ): Promise<RecipeSummaryListDto> {
     return this.recipeService.getBookmarkedRecipeSummary(user.id);
+  }
+
+  @Get(':recipeId')
+  @UseGuards(FirebaseAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '레시피 ID로 조회' })
+  @ApiOkResponse({ type: RecipeDto })
+  async getRecipeById(
+    @CurrentUser() user: UserData,
+    @Param('recipeId') recipeId: string,
+  ): Promise<RecipeDto> {
+    return this.recipeService.getRecipeById(recipeId, user.id);
   }
 }

--- a/src/recipe/recipe.service.ts
+++ b/src/recipe/recipe.service.ts
@@ -6,10 +6,7 @@ import { RecipeCreateInput } from './type/recipe-create-input.type';
 import { CreateRecipeDto } from './dto/create-recipe.dto';
 import { RecipeBookmarkDto } from './dto/recipe-bookmark.dto';
 import { RecipeDto } from './dto/recipe.dto';
-import {
-  RecipeSummaryDto,
-  RecipeSummaryListDto,
-} from './dto/recipe-summary.dto';
+import { RecipeSummaryListDto } from './dto/recipe-summary.dto';
 
 @Injectable()
 export class RecipeService {


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [ ] Improvement
- [ ] New feature
- [X] Bug fix
- [ ] CI/CD, INFRA
- [ ] Etc

## Purpose
- 레시피의 썸네일 사진을 선택할때, 반드시 저자의 meal에서 가져오도록 로직을 수정했습니다.
- 대상이 되는 데이터는 RecipeSummary인데, 이걸 사용중인 쿼리가 3군데 있었습니다. 다음과 같습니다.
   1. GET meals/:mealId
   2. GET recipes/bookmark
   3. GET recipes/users/:userId
  
  이중, 3번째 경우는 조회할때 가져오는 recipe의 userID가 모두 동일하므로, 연관된 Meal을 그대로 가져오면 되어서 수정할 것이 없었고, 1,2만 수정했습니다.

## Related issue
- resolve #54 

## Additional context
- 조회할때 아래처럼 raw query를 사용하면 훨씬 간단한데, 아무리봐도 prisma에서 할 수 있는 방법이 없어서, 분리해서 요청했습니다.
```
SELECT Meal.id, Meal.photo
FROM Meal
INNER JOIN Recipe ON Recipe.id = Meal.recipeId
WHERE Meal.userId = Recipe.userId
```