### PR TITLE
[Schema] Meal의 description 이름을 memo로 변경

### DIFF
--- a/prisma/migrations/20230324083617_change_meal_description_to_memo/migration.sql
+++ b/prisma/migrations/20230324083617_change_meal_description_to_memo/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `description` on the `meal` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "meal" ADD COLUMN "memo" TEXT;
+
+/* copy data from description to memo */
+UPDATE "meal" SET "memo" = "description";
+
+/* drop description column */
+ALTER TABLE "meal" DROP COLUMN "description";
+
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,15 +61,15 @@ model RecipeStep {
 }
 
 model Meal {
-  id          String   @id @default(uuid())
-  userId      String   @map("user_id")
-  recipeId    String   @map("recipe_id")
-  createdAt   DateTime @default(now()) @map("created_at")
-  updatedAt   DateTime @updatedAt @map("updated_at")
-  title       String
-  description String?
-  photo       String?
-  date        DateTime @db.Date
+  id        String   @id @default(uuid())
+  userId    String   @map("user_id")
+  recipeId  String   @map("recipe_id")
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+  title     String
+  memo      String?
+  photo     String?
+  date      DateTime @db.Date
 
   User   User   @relation(fields: [userId], references: [id])
   Recipe Recipe @relation(fields: [recipeId], references: [id])

--- a/src/meal/dto/meal-summary.dto.ts
+++ b/src/meal/dto/meal-summary.dto.ts
@@ -25,7 +25,7 @@ export class MealSummaryDto {
     description: '식단 설명',
     nullable: true,
   })
-  description!: string | null;
+  memo!: string | null;
 
   @ApiProperty({
     type: String,
@@ -72,7 +72,7 @@ export class MealSummaryListDto {
         id: meal.id,
         userId: meal.userId,
         title: meal.title,
-        description: meal.description,
+        memo: meal.memo,
         recipeName: meal.recipe.name,
         categoryIds: meal.categories,
         photo: meal.photo,

--- a/src/meal/dto/meal.dto.ts
+++ b/src/meal/dto/meal.dto.ts
@@ -1,6 +1,4 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { number } from 'joi';
-import * as _ from 'lodash';
 import { RecipeSummaryDto } from 'src/recipe/dto/recipe-summary.dto';
 import { MealData } from '../type/meal.type';
 
@@ -34,7 +32,7 @@ export class MealDto {
     description: '식단 설명',
     nullable: true,
   })
-  description!: string | null;
+  memo!: string | null;
 
   @ApiProperty({
     type: String,
@@ -55,21 +53,13 @@ export class MealDto {
   date!: Date;
 
   static of(meal: MealData): MealDto {
-    const {
-      id,
-      title,
-      userId,
-      description,
-      recipe,
-      date,
-      photo,
-      carbonFootprint,
-    } = meal;
+    const { id, title, userId, memo, recipe, date, photo, carbonFootprint } =
+      meal;
     return {
       id,
       title,
       userId,
-      description,
+      memo,
       recipe,
       photo,
       date,

--- a/src/meal/meal.repository.ts
+++ b/src/meal/meal.repository.ts
@@ -16,7 +16,7 @@ export class MealRepository {
         title: data.title,
         userId: data.userId,
         recipeId: data.recipeId,
-        description: data.description,
+        memo: data.memo,
         photo: data.photo,
         date: data.date,
       },
@@ -24,7 +24,7 @@ export class MealRepository {
         id: true,
         title: true,
         userId: true,
-        description: true,
+        memo: true,
         date: true,
         photo: true,
         Recipe: {
@@ -49,7 +49,7 @@ export class MealRepository {
       id: meal.id,
       title: meal.title,
       userId: meal.userId,
-      description: meal.description,
+      memo: meal.memo,
       date: meal.date,
       photo: meal.photo,
       carbonFootprint: meal.Recipe.carbonFootprint,
@@ -71,7 +71,7 @@ export class MealRepository {
       data: {
         title: data.title,
         recipeId: data.recipeId,
-        description: data.description,
+        memo: data.memo,
         photo: data.photo,
         date: data.date,
       },
@@ -99,7 +99,7 @@ export class MealRepository {
         id: true,
         title: true,
         userId: true,
-        description: true,
+        memo: true,
         date: true,
         photo: true,
         Recipe: {
@@ -136,7 +136,7 @@ export class MealRepository {
       id: meal.id,
       title: meal.title,
       userId: meal.userId,
-      description: meal.description,
+      memo: meal.memo,
       date: meal.date,
       photo: meal.photo,
       carbonFootprint: recipe!.carbonFootprint,
@@ -173,7 +173,7 @@ export class MealRepository {
         id: true,
         title: true,
         userId: true,
-        description: true,
+        memo: true,
         date: true,
         photo: true,
         Recipe: {
@@ -199,7 +199,7 @@ export class MealRepository {
       id: meal.id,
       title: meal.title,
       userId: meal.userId,
-      description: meal.description,
+      memo: meal.memo,
       date: meal.date,
       photo: meal.photo,
 
@@ -252,7 +252,7 @@ export class MealRepository {
         id: true,
         title: true,
         userId: true,
-        description: true,
+        memo: true,
         date: true,
         photo: true,
         Recipe: {
@@ -278,7 +278,7 @@ export class MealRepository {
       id: meal.id,
       title: meal.title,
       userId: meal.userId,
-      description: meal.description,
+      memo: meal.memo,
       date: meal.date,
       photo: meal.photo,
       recipe: {
@@ -313,18 +313,5 @@ export class MealRepository {
         },
       })
       .then((count) => count > 0);
-  }
-
-  async getAuthorId(mealId: string): Promise<string> {
-    const meal = await this.prisma.meal.findUnique({
-      where: {
-        id: mealId,
-      },
-      select: {
-        userId: true,
-      },
-    });
-
-    return meal!.userId;
   }
 }

--- a/src/meal/meal.service.ts
+++ b/src/meal/meal.service.ts
@@ -22,7 +22,7 @@ export class MealService {
     const input: CreateMealInput = {
       userId,
       title: payload.title,
-      description: payload.description ?? null,
+      memo: payload.memo ?? null,
       photo: payload.photo ?? null,
       date: payload.date,
       recipeId: payload.recipeId,
@@ -80,7 +80,7 @@ export class MealService {
 
     const input: UpdateMealInput = {
       title: payload.title,
-      description: payload.description ?? null,
+      memo: payload.memo ?? null,
       photo: payload.photo ?? null,
       date: payload.date,
       recipeId: payload.recipeId,

--- a/src/meal/payload/meal.payload.ts
+++ b/src/meal/payload/meal.payload.ts
@@ -26,7 +26,7 @@ export class MealPayload {
     description: '식단 설명',
     nullable: true,
   })
-  description?: string | null;
+  memo?: string | null;
 
   @IsOptional()
   @IsString()

--- a/src/meal/type/create-meal-input.type.ts
+++ b/src/meal/type/create-meal-input.type.ts
@@ -2,7 +2,7 @@ export type CreateMealInput = {
   title: string;
   userId: string;
   recipeId: string;
-  description: string | null;
+  memo: string | null;
   photo: string | null;
   date: Date;
 };

--- a/src/meal/type/meal-summary.type.ts
+++ b/src/meal/type/meal-summary.type.ts
@@ -2,7 +2,7 @@ export type MealSummary = {
   id: string;
   userId: string;
   title: string;
-  description: string | null;
+  memo: string | null;
   recipe: {
     name: string;
     carbonFootprint: number;

--- a/src/meal/type/meal.type.ts
+++ b/src/meal/type/meal.type.ts
@@ -4,7 +4,7 @@ export type MealData = {
   id: string;
   title: string;
   userId: string;
-  description: string | null;
+  memo: string | null;
   photo: string | null;
   carbonFootprint: number;
   date: Date;

--- a/src/meal/type/update-meal-input.type.ts
+++ b/src/meal/type/update-meal-input.type.ts
@@ -1,7 +1,7 @@
 export type UpdateMealInput = {
   title: string;
   recipeId: string;
-  description: string | null;
+  memo: string | null;
   photo: string | null;
   date: Date;
 };


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [ ] Improvement
- [X] New feature
- [ ] Bug fix
- [ ] CI/CD, INFRA
- [ ] Etc

## Purpose
- 이전 회의에서 Meal의 Description을 해당 이름으로 하는 것이 맥락상 맞지 않아 memo로 통일하기로 하였으므로, 이를 반영합니다.

## Related issue
- resolve #62 

## Additional context
- DB의 컬럼이 변경되었으므로, 로컬에서 테스트할때 migration을 적용해주세요.

## Checklist
- 배포 전에 dev DB에 migration 적용해야 build 성공합니다.
