### PR TITLE
[Fix] 유저 수정 로직 개선 & meal 검색 시 쿼리가 없는 경우 대응

### DIFF
--- a/src/meal/dto/meal-summary.dto.ts
+++ b/src/meal/dto/meal-summary.dto.ts
@@ -34,7 +34,7 @@ export class MealSummaryDto {
   recipeName!: string;
 
   @ApiProperty({
-    type: String,
+    type: [String],
     description: '재료 카테고리 리스트',
   })
   categoryIds!: string[];

--- a/src/meal/meal.repository.ts
+++ b/src/meal/meal.repository.ts
@@ -216,7 +216,15 @@ export class MealRepository {
   }
 
   async getPossibleIngredientIds(typeId?: string): Promise<string[]> {
-    const ingredients = await this.prisma.veganType.findUnique({
+    if (!typeId) {
+      const ingredients = await this.prisma.ingredient.findMany({
+        select: {
+          id: true,
+        },
+      });
+      return ingredients.map((i) => i.id);
+    }
+    const ingredients = await this.prisma.veganType.findFirst({
       where: {
         id: typeId,
       },

--- a/src/meal/meal.service.ts
+++ b/src/meal/meal.service.ts
@@ -41,10 +41,10 @@ export class MealService {
 
   async searchMeal(
     userId: string,
-    typeId?: string,
+    typeId?: string | null,
   ): Promise<MealSummaryListDto> {
     const possibleIngredientIds =
-      await this.mealRepository.getPossibleIngredientIds(typeId);
+      await this.mealRepository.getPossibleIngredientIds(typeId ?? undefined);
 
     if (possibleIngredientIds.length === 0) {
       throw new NotFoundException('잘못된 vegan type입니다.');

--- a/src/meal/query/search-meal.query.ts
+++ b/src/meal/query/search-meal.query.ts
@@ -1,11 +1,13 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { IsString } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
 
 export class SearchMealQuery {
+  @IsOptional()
   @IsString()
   @ApiPropertyOptional({
     type: String,
     description: '비건 타입',
+    nullable: true,
   })
-  typeId?: string;
+  typeId?: string | null;
 }

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -8,31 +8,7 @@ import { MealList } from './type/user-meal.type';
 export class UserRepository {
   constructor(private readonly prisma: PrismaService) {}
 
-  async updateUser(
-    userId: string,
-    data: UserPayload,
-  ): Promise<UserData | null> {
-    const userValid = await this.prisma.meal.findUnique({
-      where: {
-        id: userId,
-      },
-      select: {
-        id: true,
-      },
-    });
-    if (!userValid) return null;
-
-    const nameValid = await this.prisma.user.findFirst({
-      where: {
-        name: data.name,
-        deletedAt: null,
-      },
-      select: {
-        id: true,
-      },
-    });
-    if (nameValid) return null;
-
+  async updateUser(userId: string, data: UserPayload): Promise<UserData> {
     const user = await this.prisma.user.update({
       where: {
         id: userId,
@@ -43,12 +19,11 @@ export class UserRepository {
       },
     });
 
-    const resData: UserData = {
+    return {
       id: user.id,
       name: user.name,
       photo: user.photo,
     };
-    return resData;
   }
 
   async getMealListByUserId(userId: string): Promise<MealList | null> {
@@ -90,5 +65,32 @@ export class UserRepository {
       photo: userInfo.photo,
       mealList: mealList,
     };
+  }
+
+  async getUserInfo(userId: string): Promise<UserData | null> {
+    const userInfo = await this.prisma.user.findUnique({
+      where: { id: userId },
+      select: { id: true, name: true, photo: true },
+    });
+    if (!userInfo) return null;
+
+    return {
+      id: userInfo.id,
+      name: userInfo.name,
+      photo: userInfo.photo,
+    };
+  }
+
+  async checkDuplicateName(name: string): Promise<boolean> {
+    const user = await this.prisma.user.findFirst({
+      where: {
+        name: name,
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+      },
+    });
+    return !!user;
   }
 }


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [ ] Improvement
- [ ] New feature
- [X] Bug fix
- [ ] CI/CD, INFRA
- [ ] Etc

## Purpose
- 유저 수정시 이름의 중복체크하는 과정에서 이름이 현재와 같다는 이유로 update가 거부되는 현상을 수정합니다.
- meal 검색 시에 쿼리가 없는 경우도 대응이 가능하도록 수정합니다.

## Related issue
- resolve #67 
