### PR TITLE
[Fix] avgFootprint가 meal이 0개일 때 null로 내려가던 현상 수정

### DIFF
--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -63,7 +63,8 @@ export class UserService {
       const date = new Date(dateStr);
       mealCountsByDate.push({ date, count });
     }
-    const avgFootprint = totalMealFootprint / totalMealCount;
+    const avgFootprint =
+      totalMealCount === 0 ? 0 : totalMealFootprint / totalMealCount;
 
     const diffDays = this.getDiffDays(meals.createdAt);
 


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [ ] Improvement
- [ ] New feature
- [X] Bug fix
- [ ] CI/CD, INFRA
- [ ] Etc

## Purpose
- js는 0으로 나누면 null이 되나봅니다,,,(?)


## Related issue
- resolve #73 
